### PR TITLE
global css fix for font default color

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -58,6 +58,19 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+input:not([class*="text-"]),
+textarea:not([class*="text-"]),
+select:not([class*="text-"]) {
+  color: #111827;
+  caret-color: #111827;
+}
+
+input:not([class*="placeholder:"])::placeholder,
+textarea:not([class*="placeholder:"])::placeholder {
+  color: #6b7280;
+  opacity: 1;
+}
+
 /* Dashboard background dot grid */
 .dm-bg-field::before {
   content: "";

--- a/src/app/store/[subdomain]/components/ProductSection.tsx
+++ b/src/app/store/[subdomain]/components/ProductSection.tsx
@@ -1,4 +1,4 @@
-import { Heart, ShoppingCart } from "lucide-react";
+import { ShoppingCart } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useCart } from "../context/Cartcontext ";
 
@@ -139,9 +139,6 @@ export default function ProductsSection() {
                     Low Stock
                   </div>
                 )}
-                <button className="absolute top-2 left-2 sm:top-3 sm:left-3 p-1.5 sm:p-2 bg-white rounded-full shadow-md hover:bg-gray-100 opacity-0 group-hover:opacity-100 transition-opacity text-lg">
-                  <Heart className="w-5 h-5 text-gray-700" />
-                </button>
               </div>
               <div className="p-3 sm:p-4 flex flex-col flex-grow">
                 <h3 className="font-semibold text-xs sm:text-sm md:text-base text-gray-900 mb-1 sm:mb-1.5 line-clamp-2">


### PR DESCRIPTION
## Summary by Sourcery

Set default text and placeholder colors for form inputs via global CSS and remove the unused wishlist heart button from the product card UI.

New Features:
- Define global default text and caret color for inputs, textareas, and selects that do not use Tailwind text color utility classes.
- Define global default placeholder color and opacity for inputs and textareas that do not use Tailwind placeholder utility classes.

Enhancements:
- Simplify the product card layout by removing the wishlist heart icon button from the product section component.